### PR TITLE
Patch for Blank Fields

### DIFF
--- a/classes/class-jobvite.php
+++ b/classes/class-jobvite.php
@@ -136,8 +136,7 @@ class Jobvite_Career_Sync {
 		foreach($xml->job as $job){
 			/* Confirm all required fields exist */
 			if( empty($job->location) || 
-				trim( $job->location ) == '' || empty($job->region) ||
-				 trim( $job->region ) == '' || empty($job->jobtype) ||
+				trim( $job->location ) == '' ||  empty($job->jobtype) ||
 				  trim( $job->jobtype ) == '' || empty($job->category) ||
 				   trim( $job->category ) == '' 
 				   ) 

--- a/classes/class-jobvite.php
+++ b/classes/class-jobvite.php
@@ -134,6 +134,11 @@ class Jobvite_Career_Sync {
 		/* Loop Jobs */
 		$counter = 0;
 		foreach($xml->job as $job){
+			/* Confirm all required fields exist */
+			$job->location = false;
+			if( trim( $job->location ) == '' || trim( $job->region ) == '' || trim( $job->jobtype ) == '' || trim( $job->category ) == '' ) {
+				continue;
+			}
 			/* Cast ID as string */
 			$id = (string) $job->id;
 			/* Add ID to Jobvite ID Array */

--- a/classes/class-jobvite.php
+++ b/classes/class-jobvite.php
@@ -135,8 +135,13 @@ class Jobvite_Career_Sync {
 		$counter = 0;
 		foreach($xml->job as $job){
 			/* Confirm all required fields exist */
-			$job->location = false;
-			if( trim( $job->location ) == '' || trim( $job->region ) == '' || trim( $job->jobtype ) == '' || trim( $job->category ) == '' ) {
+			if( empty($job->location) || 
+				trim( $job->location ) == '' || empty($job->region) ||
+				 trim( $job->region ) == '' || empty($job->jobtype) ||
+				  trim( $job->jobtype ) == '' || empty($job->category) ||
+				   trim( $job->category ) == '' 
+				   ) 
+			{
 				continue;
 			}
 			/* Cast ID as string */


### PR DESCRIPTION
In case a field is left empty in JobVite (which had previously thrown an error for syncing), this logic skips a job if it has an empty field. 
